### PR TITLE
Fix GitHub Pages 404 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,10 @@ npm install
 npm start
 ```
 
-Parcel will serve the application and open it in your browser. When you are ready
-to deploy a static build use:
+Parcel will serve the application and open it in your browser. When you are ready to deploy a static build use:
 
 ```bash
 npm run build
 ```
 
-The contents of the `build/` directory can then be hosted with any static file
-server.
+The contents of the `build/` directory can then be hosted with any static file server. The build script sets `--public-url ./` so asset paths remain relative, which is necessary for hosting on GitHub Pages project sites.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple single page application built with React",
   "scripts": {
     "start": "parcel app/index.html",
-    "build": "parcel build app/index.html --dist-dir build"
+    "build": "parcel build app/index.html --dist-dir build --public-url ./"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- ensure Parcel outputs relative URLs for assets
- explain GitHub Pages setup in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688796929ec88327b28844cfbe33f468